### PR TITLE
Move CitrusRobot * argument to argument vector

### DIFF
--- a/objects/function.py
+++ b/objects/function.py
@@ -92,6 +92,7 @@ class Function(object):
         var_init_lines = []
 
         cast_functions = {
+            "CitrusRobot *":       "(CitrusRobot *)({})",
             "int":                 "ConvertArgs::ls_convert_int({})",
             "bool":                "ConvertArgs::ls_convert_bool({})",
             "float":               "ConvertArgs::ls_convert_float({})",
@@ -146,6 +147,8 @@ class Function(object):
                 arg = arg.strip()
                 arg_pair = [arg.strip().split(" ")[0], arg.strip().split(" ")[-1]]
                 args.append(arg_pair)
+
+        args.insert(0, ["CitrusRobot *", "robot"])
         return args
 
     def get_raw_constructor(self):

--- a/tests/files/transpiler/base_class.h
+++ b/tests/files/transpiler/base_class.h
@@ -3,8 +3,8 @@
 
 class BaseAutoFunction {
   public:
-    bool Init(CitrusRobot *robot, std::vector<void *>);
-    bool Periodic(CitrusRobot *robot, std::vector<void *>);
+    bool Init(std::vector<void *>);
+    bool Periodic(std::vector<void *>);
   private:
     //none
 };

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -58,12 +58,12 @@ class TestFunctionMethods:
         test_text = test_file.read()
         test_file.close()
         test_results = [
-            [],
-            [["int", "i"]],
-            [],
-            [["int", "i"], ["Time", "t"]],
-            [],
-            [["int", "i"], ["Time", "t"]]
+            [['CitrusRobot *', 'robot']],
+            [['CitrusRobot *', 'robot'], ["int", "i"]],
+            [['CitrusRobot *', 'robot']],
+            [['CitrusRobot *', 'robot'], ["int", "i"], ["Time", "t"]],
+            [['CitrusRobot *', 'robot']],
+            [['CitrusRobot *', 'robot'], ["int", "i"], ["Time", "t"]]
         ]
 
         n = 0

--- a/text_includes/auto_function_class.cpp.skel
+++ b/text_includes/auto_function_class.cpp.skel
@@ -1,9 +1,9 @@
 // vim: filetype=cpp:
 
-bool <<<name>>>Class::Init(CitrusRobot *robot, std::vector<void *> ls_arg_list) {
+bool <<<name>>>Class::Init(std::vector<void *> ls_arg_list) {
   <<<init_code>>>
 }
 
-bool <<<name>>>Class::Periodic(CitrusRobot *robot, std::vector<void *> ls_arg_list) {
+bool <<<name>>>Class::Periodic(std::vector<void *> ls_arg_list) {
   <<<periodic_code>>>
 }

--- a/text_includes/auto_function_class.h.skel
+++ b/text_includes/auto_function_class.h.skel
@@ -2,8 +2,8 @@
 
 class <<<name>>>Class : public BaseAutoFunction {
   public:
-    bool Init(CitrusRobot *robot, std::vector<void *> ls_arg_list);
-    bool Periodic(CitrusRobot *robot, std::vector<void *> ls_arg_list);
+    bool Init(std::vector<void *> ls_arg_list);
+    bool Periodic(std::vector<void *> ls_arg_list);
   private:
     //<<<vars>>>
 };

--- a/transpiler.py
+++ b/transpiler.py
@@ -32,7 +32,8 @@ def generate_auto_functions(auto_function_objects):
         auto_classes_cpp_file.insert_text("classes", auto_function.get_class()[1])
         auto_classes_h_file.insert_text("generators", auto_function.get_generator()[0])
         auto_classes_cpp_file.insert_text("generators", auto_function.get_generator()[1])
-        auto_classes_cpp_file.insert_text("addgenerators", File(open(get_script_dir() + "text_includes/add_to_return_vector.skel").read(), [["replace_text", "name", auto_function.get_name()], ["replace_text", "args", "-".join([argl[0] for argl in auto_function.get_args()])]]).text)
+        auto_function_arg_string = "-".join([argl[0] for argl in auto_function.get_args()[1:]])
+        auto_classes_cpp_file.insert_text("addgenerators", File(open(get_script_dir() + "text_includes/add_to_return_vector.skel").read(), [["replace_text", "name", auto_function.get_name()], ["replace_text", "args", auto_function_arg_string]]).text)
 
     includes = ["#include " + name for name in includes]
     auto_classes_h_file.insert_text("include", "\n".join(includes))


### PR DESCRIPTION
I moved CitrusRobot \* argument to the vector of void pointers.  Feel free to edit as you wish.
