### PR TITLE
Fix missing include in generated C++

### DIFF
--- a/text_includes/auto_classes.h.skel
+++ b/text_includes/auto_classes.h.skel
@@ -8,6 +8,7 @@
 #include <functional>
 #include <memory>
 #include <map>
+#include <string>
 #include "third_party/lemonscript/lemonscript/BaseAutoFunction.h"
 
 using lemonscript::BaseAutoFunction;


### PR DESCRIPTION
You are using std::string below, so this should be here in case the includer isn't already including std::string.